### PR TITLE
Implement a CLI flag handling skeleton

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ImplicitParams #-}
 
 {-# OPTIONS_GHC -Wno-unused-imports #-}
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
 
 module Main where
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,7 +24,7 @@ import qualified Data.Map as Map
 main :: IO ()
 main = do
   flags <- extractFlags
-  print flags
+  -- print flags
 
   checkSanity flags
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,9 +23,6 @@ import qualified Data.Map as Map
 
 main :: IO ()
 main = do
-  -- TODO: proper error handling
-  -- TODO: handle command-line arguments correctly (flags, options, etc)
-
   flags <- extractFlags
   print flags
 
@@ -58,6 +55,10 @@ tryCompile flags file = do
   content <- Text.readFile file
 
   let withColor = maybe "yes" id (lookupFlag "color-diagnostics" flags) == "yes"
+
+  -- TODO: construct implicit structures for each compiler step
+
+  -- TODO: proper error handling
 
   tokens <- case lexFile file content of
     Left diag -> do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -55,7 +55,7 @@ tryCompile :: CompilerFlags -> String -> IO ()
 tryCompile flags file = do
   content <- Text.readFile file
 
-  let withColor = lookupFlag "color-diagnostics" flags == Just "yes"
+  let withColor = maybe "yes" id (lookupFlag "color-diagnostics" flags) == "yes"
 
   tokens <- case lexFile file content of
     Left diag -> do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Main where
@@ -5,20 +9,53 @@ module Main where
 import Language.NStar.Syntax (lexFile, parseFile)
 import Language.NStar.Typechecker (typecheck)
 import Text.Diagnose (printDiagnostic, (<~<))
-import System.IO (stderr, stdout, hPrint, hPutStr)
-import GHC.ResponseFile (getArgsWithResponseFiles)
+import System.IO (stderr, stdout)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
+import Console.NStar.Flags
+import Control.Monad (forM_, guard)
+import Control.Applicative ((<|>))
+import System.Exit (exitFailure)
+import Data.Char (toLower)
+import qualified Data.Map as Map
 
 main :: IO ()
 main = do
   -- TODO: proper error handling
   -- TODO: handle command-line arguments correctly (flags, options, etc)
- 
-  (file : _) <- getArgsWithResponseFiles
+
+  flags <- extractFlags
+  print flags
+
+  checkSanity flags
+
+  forM_ (files flags) (tryCompile flags)
+
+------------------------------------------------------------------------------------------------
+
+checkSanity :: CompilerFlags -> IO ()
+checkSanity CFlags{..} = do
+  flip Map.traverseWithKey flags \ n@(fmap toLower -> name) v@(fmap toLower -> val) -> do
+    guard (name `elem` knownConfigFlags)
+      <|> (putStrLn ("Unrecognized configuration flag '" <> n <> "'.") *> exitFailure)
+
+    case name of
+      "color-diagnostics" ->
+        guard (val == "yes" || val == "no")
+          <|> (putStrLn ("Expected either 'yes' or 'no' for configuration flag '" <> n <> "', but got '" <> v <> "'.") *> exitFailure)
+      _ -> error "configuration flag name already filtered out."
+
+  pure ()
+
+knownConfigFlags :: [String]
+knownConfigFlags = [ "color-diagnostics" ]
+
+
+tryCompile :: CompilerFlags -> String -> IO ()
+tryCompile flags file = do
   content <- Text.readFile file
 
-  let withColor = True
+  let withColor = lookupFlag "color-diagnostics" flags == Just "yes"
 
   tokens <- case lexFile file content of
     Left diag -> do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -56,8 +56,6 @@ tryCompile flags file = do
 
   let withColor = maybe "yes" id (lookupFlag "color-diagnostics" flags) == "yes"
 
-  -- TODO: construct implicit structures for each compiler step
-
   -- TODO: proper error handling
 
   let ?lexerFlags  = LexerFlags {}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -60,6 +60,10 @@ tryCompile flags file = do
 
   -- TODO: proper error handling
 
+  let ?lexerFlags  = LexerFlags {}
+  let ?parserFlags = ParserFlags {}
+  let ?tcFlags     = TypecheckerFlags {}
+
   tokens <- case lexFile file content of
     Left diag -> do
       printDiagnostic withColor stderr (diag <~< (file, lines $ Text.unpack content))

--- a/default-extensions.yaml
+++ b/default-extensions.yaml
@@ -1,3 +1,4 @@
 - BlockArguments
 - LambdaCase
 - BinaryLiterals
+- ImplicitParams

--- a/lib/nsc-core/nsc-core.cabal
+++ b/lib/nsc-core/nsc-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0e520d30ae6713c3b2f789c1efca93f1b08b50c82a2b4f17d455cea910276cde
+-- hash: 2dce9a45fc377545ea769de74641f09786ec793246332bb33c8e6f64c5a48c15
 
 name:           nsc-core
 version:        0.0.1.0
@@ -19,7 +19,7 @@ library
       Paths_nsc_core
   hs-source-dirs:
       src
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   build-depends:
       base >=4.7 && <5
     , containers >=0.6

--- a/lib/nsc-flags/nsc-flags.cabal
+++ b/lib/nsc-flags/nsc-flags.cabal
@@ -1,0 +1,26 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           nsc-flags
+version:        0.0.1.0
+build-type:     Simple
+
+library
+  exposed-modules:
+      Console.NStar.Flags
+      Console.NStar.Flags.Internal
+      Console.NStar.Flags.Process
+  other-modules:
+      Paths_nsc_flags
+  hs-source-dirs:
+      src
+  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  build-depends:
+      base >=4.7 && <5
+    , cmdargs
+    , containers
+    , extra
+  default-language: Haskell2010

--- a/lib/nsc-flags/nsc-flags.cabal
+++ b/lib/nsc-flags/nsc-flags.cabal
@@ -17,7 +17,7 @@ library
       Paths_nsc_flags
   hs-source-dirs:
       src
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   build-depends:
       base >=4.7 && <5
     , cmdargs

--- a/lib/nsc-flags/package.yaml
+++ b/lib/nsc-flags/package.yaml
@@ -1,0 +1,13 @@
+name: nsc-flags
+version: !include "../../version.yaml"
+
+library:
+  source-dirs: src
+
+default-extensions: !include "../../default-extensions.yaml"
+
+dependencies:
+- base >=4.7 && <5
+- cmdargs
+- extra
+- containers

--- a/lib/nsc-flags/src/Console/NStar/Flags.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags.hs
@@ -4,9 +4,10 @@ module Console.NStar.Flags
 ( extractFlags
 ,  -- * Re-exports
   CompilerFlags(..)
+, lookupFlag
 ) where
 
-import Console.NStar.Flags.Internal (Flags(..), CompilerFlags(..))
+import Console.NStar.Flags.Internal (Flags(..), CompilerFlags(..), lookupFlag)
 import Console.NStar.Flags.Process
 import System.Console.CmdArgs
 

--- a/lib/nsc-flags/src/Console/NStar/Flags.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Console.NStar.Flags
+( extractFlags
+,  -- * Re-exports
+  CompilerFlags(..)
+) where
+
+import Console.NStar.Flags.Internal (Flags(..), CompilerFlags(..))
+import Console.NStar.Flags.Process
+import System.Console.CmdArgs
+
+extractFlags :: IO CompilerFlags
+extractFlags = postProcessFlags =<< cmdArgsRun (cmdArgsMode cli)
+
+cli :: Flags
+cli = Flags
+  { files = def &= args &= typ "FILES..."
+  , flags = def &= typ "NAME=VALUE" &= explicit &= name "f" &= name "flag"
+  } &= versionArg [ignore]
+    &= helpArg [explicit, name "help", name "h"]
+    &= program "nsc"

--- a/lib/nsc-flags/src/Console/NStar/Flags.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags.hs
@@ -17,7 +17,7 @@ extractFlags = postProcessFlags =<< cmdArgsRun (cmdArgsMode cli)
 cli :: Flags
 cli = Flags
   { files = def &= args &= typ "FILES..."
-  , flags = def &= typ "NAME=VALUE" &= explicit &= name "f" &= name "flag"
+  , flags = def &= typ "NAME=VALUE" &= explicit &= name "f" &= name "flag" &= help "Sets a compiler flag to a given value"
   } &= versionArg [ignore]
     &= helpArg [explicit, name "help", name "h"]
     &= program "nsc"

--- a/lib/nsc-flags/src/Console/NStar/Flags.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags.hs
@@ -5,9 +5,10 @@ module Console.NStar.Flags
 ,  -- * Re-exports
   CompilerFlags(..)
 , lookupFlag
+, LexerFlags(..), ParserFlags(..), TypecheckerFlags(..)
 ) where
 
-import Console.NStar.Flags.Internal (Flags(..), CompilerFlags(..), lookupFlag)
+import Console.NStar.Flags.Internal
 import Console.NStar.Flags.Process
 import System.Console.CmdArgs
 

--- a/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Console.NStar.Flags.Internal
+( Flags(..), CompilerFlags(..)
+) where
+
+import Data.Data (Data)
+import Data.Typeable (Typeable)
+import Data.Map (Map)
+
+data CompilerFlags
+  = CFlags
+  { files :: [FilePath]
+  , flags :: Map String String
+  }
+ deriving (Show)
+
+
+
+data Flags
+  = Flags
+  { files  :: [FilePath]      -- ^ The path to all the files to compile.
+  , flags  :: [String]        -- ^ A set of compiler flags.
+  }
+ deriving (Data, Typeable, Show)

--- a/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
@@ -26,3 +26,17 @@ data Flags
   , flags  :: [String]        -- ^ A set of compiler flags.
   }
  deriving (Data, Typeable, Show)
+
+-------------------------------------------------------------------------------
+
+data LexerFlags
+  = LexerFlags
+  {  }
+
+data ParserFlags
+  = ParserFlags
+  {  }
+
+data TypecheckerFlags
+  = TypecheckerFlags
+  {  }

--- a/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
@@ -2,10 +2,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Console.NStar.Flags.Internal
-( Flags(..), CompilerFlags(..)
-, lookupFlag
-) where
+module Console.NStar.Flags.Internal where
 
 import Data.Data (Data)
 import Data.Typeable (Typeable)

--- a/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags/Internal.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Console.NStar.Flags.Internal
 ( Flags(..), CompilerFlags(..)
+, lookupFlag
 ) where
 
 import Data.Data (Data)
 import Data.Typeable (Typeable)
 import Data.Map (Map)
+import qualified Data.Map as Map
 
 data CompilerFlags
   = CFlags
@@ -16,6 +19,8 @@ data CompilerFlags
   }
  deriving (Show)
 
+lookupFlag :: String -> CompilerFlags -> Maybe String
+lookupFlag name CFlags{flags} = Map.lookup name flags
 
 
 data Flags

--- a/lib/nsc-flags/src/Console/NStar/Flags/Process.hs
+++ b/lib/nsc-flags/src/Console/NStar/Flags/Process.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Console.NStar.Flags.Process
+( postProcessFlags
+) where
+
+import Console.NStar.Flags.Internal
+import Data.List.Extra (stripInfix)
+import qualified Data.Map as Map
+
+postProcessFlags :: Flags -> IO CompilerFlags
+postProcessFlags Flags{ files = _files
+                      , flags = _flags
+                      } = do
+  pure $ CFlags
+    { files = _files
+    , flags = Map.fromList (parseFlag <$> _flags)
+    }
+
+parseFlag :: String -> (String, String)
+parseFlag s = maybe (s, "") id (stripInfix "=" s)

--- a/lib/nsc-parser/nsc-parser.cabal
+++ b/lib/nsc-parser/nsc-parser.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1118b25c2dadde7dac72ff74a29bc61e968ff7636024bb03c5e289aea9fb5b0d
+-- hash: 2a028fa61a4936ef5fc24090cc648233c9b172542e2720823f5306331994eab4
 
 name:           nsc-parser
 version:        0.0.1.0
@@ -20,7 +20,7 @@ library
       Paths_nsc_parser
   hs-source-dirs:
       src
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   ghc-options: -Wno-name-shadowing -Wall
   build-depends:
       base >=4.7 && <5

--- a/lib/nsc-parser/nsc-parser.cabal
+++ b/lib/nsc-parser/nsc-parser.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2a028fa61a4936ef5fc24090cc648233c9b172542e2720823f5306331994eab4
+-- hash: 1077d794d335e1721ff96fb1b792634ec46cf31561fa921edf5d80a1f6b778e4
 
 name:           nsc-parser
 version:        0.0.1.0
@@ -28,5 +28,6 @@ library
     , diagnose
     , megaparsec >=8.0
     , nsc-core
+    , nsc-flags
     , text >=1.2 && <1.4
   default-language: Haskell2010

--- a/lib/nsc-parser/package.yaml
+++ b/lib/nsc-parser/package.yaml
@@ -13,6 +13,7 @@ dependencies:
 - containers >=0.6
 - nsc-core
 - megaparsec >=8.0
+- nsc-flags
 
 ghc-options:
 - -Wno-name-shadowing

--- a/lib/nsc-parser/src/Language/NStar/Syntax/Parser.hs
+++ b/lib/nsc-parser/src/Language/NStar/Syntax/Parser.hs
@@ -31,6 +31,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Located (Located(..), unLoc)
 import qualified Data.Map as Map (fromList)
+import Console.NStar.Flags (ParserFlags(..))
 
 type Parser a = MP.Parsec SemanticError [LToken] a
 
@@ -49,7 +50,7 @@ instance Hintable SemanticError String where
     [ hint "Registers are fixed depending on the target architecture."
     , hint "Registers available in different architectures are documented here: <https://github.com/nihil-lang/nsc/blob/develop/docs/registers.md>." ]
 
-lexeme :: Parser a -> Parser a
+lexeme :: (?parserFlags :: ParserFlags) => Parser a -> Parser a
 lexeme = MPL.lexeme (MPL.space MP.empty inlineComment multilineComment)
   where inlineComment = () <$ MP.satisfy isInlineComment
         isInlineComment (InlineComment _ :@ _) = True
@@ -62,27 +63,27 @@ lexeme = MPL.lexeme (MPL.space MP.empty inlineComment multilineComment)
 -------------------------------------------------------------------------------------------------
 
 -- | Turns a list of tokens into an AST, as long as tokens are well ordered. Else, it throws an error.
-parseFile :: FilePath -> [LToken] -> Either (Diagnostic [] String Char) Program
+parseFile :: (?parserFlags :: ParserFlags) => FilePath -> [LToken] -> Either (Diagnostic [] String Char) Program
 parseFile = first (megaparsecBundleToDiagnostic "Parse error on input") .: MP.runParser parseProgram
   where (.:) = (.) . (.)
 
 -- | Parses a sequence of either typed labels or instruction calls.
-parseProgram :: Parser Program
+parseProgram :: (?parserFlags :: ParserFlags) => Parser Program
 parseProgram = noise *> (Program <$> MP.many instructions) <* parseEOF
   where instructions = located (parseTypedLabel MP.<|> parseInstructionCall) <* (parseEOL MP.<|> parseEOF)
         noise = lexeme (pure ()) *> MP.many (lexeme (MP.try parseEOL))
 
 -- | Parses the end of file. There is no guarantee that any parser will try to parse something after the end of file.
 --   This has to be dealt with on our own. No more token should be available after consuming the end of file.
-parseEOF :: Parser ()
+parseEOF :: (?parserFlags :: ParserFlags) => Parser ()
 parseEOF = () <$ parseSymbol EOF
 
 -- | Parses the end of a line.
-parseEOL :: Parser ()
+parseEOL :: (?parserFlags :: ParserFlags) => Parser ()
 parseEOL = () <$ parseSymbol EOL
 
 -- | Parses an identifier and returns its textual representation.
-parseIdentifier :: Parser (Located Text)
+parseIdentifier :: (?parserFlags :: ParserFlags) => Parser (Located Text)
 parseIdentifier = MP.label "an identifier" $ lexeme do
   Id i :@ p <- MP.satisfy isIdentifier
   pure (i :@ p)
@@ -91,10 +92,10 @@ parseIdentifier = MP.label "an identifier" $ lexeme do
    isIdentifier (_ :@ _)    = False
 
 -- | Parses a symbol and returns it.
-parseSymbol :: Token -> Parser LToken
+parseSymbol :: (?parserFlags :: ParserFlags) => Token -> Parser LToken
 parseSymbol t1 = MP.label (showToken t1) . lexeme $ MP.satisfy \ (t2 :@ _) -> t2 == t1
 
-parseRegister :: Parser Register
+parseRegister :: (?parserFlags :: ParserFlags) => Parser Register
 parseRegister = MP.label "a register" $ parseSymbol Percent *> reg
   where reg = MP.choice
           [ RAX <$ parseSymbol Rax
@@ -107,7 +108,7 @@ parseRegister = MP.label "a register" $ parseSymbol Percent *> reg
           , RBP <$ parseSymbol Rbp
           , MP.lookAhead MP.anySingle >>= MP.customFailure . NoSuchRegister . unLoc ]
 
-parseInteger :: Parser (Located Integer)
+parseInteger :: (?parserFlags :: ParserFlags) => Parser (Located Integer)
 parseInteger = MP.label "an integer" $ lexeme do
   Integer i :@ p <- MP.satisfy isInteger
   pure (read (Text.unpack i) :@ p)
@@ -115,7 +116,7 @@ parseInteger = MP.label "an integer" $ lexeme do
    isInteger (Integer _ :@ _) = True
    isInteger _                = False
 
-parseCharacter :: Parser (Located Char)
+parseCharacter :: (?parserFlags :: ParserFlags) => Parser (Located Char)
 parseCharacter = MP.label "a character" $ lexeme do
   Char c :@ p <- MP.satisfy isCharacter
   pure (c :@ p)
@@ -124,42 +125,42 @@ parseCharacter = MP.label "a character" $ lexeme do
    isCharacter _             = False
 
 -- | @between opening closing p@ parses @p@ enclosed between @opening@ and @closing@.
-between :: Parser a -> Parser b -> Parser c -> Parser c
+between :: (?parserFlags :: ParserFlags) => Parser a -> Parser b -> Parser c -> Parser c
 between opening closing p = opening *> p <* closing
 
 -- | Parses something between braces.
-betweenBraces :: Parser a -> Parser a
+betweenBraces :: (?parserFlags :: ParserFlags) => Parser a -> Parser a
 betweenBraces = lexeme . between (parseSymbol LBrace) (parseSymbol RBrace)
 
 -- | Parses something between brackets.
-betweenBrackets :: Parser a -> Parser a
+betweenBrackets :: (?parserFlags :: ParserFlags) => Parser a -> Parser a
 betweenBrackets = lexeme . between (parseSymbol LBracket) (parseSymbol RBracket)
 
 -- | Parses something between parentheses.
-betweenParens :: Parser a -> Parser a
+betweenParens :: (?parserFlags :: ParserFlags) => Parser a -> Parser a
 betweenParens = lexeme . between (parseSymbol LParen) (parseSymbol RParen)
 
 -- | Parses something between angles.
-betweenAngles :: Parser a -> Parser a
+betweenAngles :: (?parserFlags :: ParserFlags) => Parser a -> Parser a
 betweenAngles = lexeme . between (parseSymbol LAngle) (parseSymbol RAngle)
 
 -- | @sepBy p sep@ parses 0 or more @p@ separated by @sep@.
-sepBy :: Parser a -> Parser b -> Parser [a]
+sepBy :: (?parserFlags :: ParserFlags) => Parser a -> Parser b -> Parser [a]
 sepBy p sep = sepBy1 p sep MP.<|> pure []
 
 -- | @sepBy1 p sep@ is much like 'sepBy' but parses at least one occurrence of @p@.
-sepBy1 :: Parser a -> Parser b -> Parser [a]
+sepBy1 :: (?parserFlags :: ParserFlags) => Parser a -> Parser b -> Parser [a]
 sepBy1 p sep = (:) <$> p <*> MP.many (sep *> p)
 
 
 -- | Parses a typed label.
-parseTypedLabel :: Parser Statement
+parseTypedLabel :: (?parserFlags :: ParserFlags) => Parser Statement
 parseTypedLabel = lexeme $
   Label <$> (parseIdentifier <* parseSymbol Colon)
         <*> located (parseForallType parseRecordType MP.<|> parseRecordType)
 
 -- | Parses an instruction call from the N*'s instruction set.
-parseInstructionCall :: Parser Statement
+parseInstructionCall :: (?parserFlags :: ParserFlags) => Parser Statement
 parseInstructionCall = MP.choice $ fmap Instr <$>
   [ parseMov
   , parseRet ]
@@ -167,7 +168,7 @@ parseInstructionCall = MP.choice $ fmap Instr <$>
 ------------------------------------------------------------------------------------------------------------
 
 -- | Parses a forall type variable binder.
-parseForallType :: Parser Type -> Parser Type
+parseForallType :: (?parserFlags :: ParserFlags) => Parser Type -> Parser Type
 parseForallType pty =
   ForAll <$> (parseSymbol Forall *> MP.some binders <* parseSymbol Dot)
          <*> located pty
@@ -177,7 +178,7 @@ parseForallType pty =
          <*> (parseSymbol Colon *> located parseKind)
 
 -- | Parses a non-stack type. To parse a stack type, see 'parseStackType'.
-parseType :: Parser Type
+parseType :: (?parserFlags :: ParserFlags) => Parser Type
 parseType = lexeme $ MP.choice
   [ parseRecordType
   , parseSignedType
@@ -189,43 +190,43 @@ parseType = lexeme $ MP.choice
   ]
 
 -- | Parses a record type.
-parseRecordType :: Parser Type
+parseRecordType :: (?parserFlags :: ParserFlags) => Parser Type
 parseRecordType = Record . Map.fromList <$> betweenBraces (field `sepBy` parseSymbol Comma)
   where
     field = (,) <$> (located parseRegister <* parseSymbol Colon) <*> located parseType
 
 -- | Parses any sort of signed integer type.
-parseSignedType :: Parser Type
+parseSignedType :: (?parserFlags :: ParserFlags) => Parser Type
 parseSignedType = fmap Signed . MP.choice $ signed <$> [ 64 ]
  where
    signed n = fromIntegral n <$ parseSymbol (Id ("s" <> Text.pack (show n)))
 
 -- | Parses any sort of unsigned integer type.
-parseUnsignedType :: Parser Type
+parseUnsignedType :: (?parserFlags :: ParserFlags) => Parser Type
 parseUnsignedType = fmap Unsigned . MP.choice $ unsigned <$> [ 64 ]
  where
    unsigned n = fromIntegral n <$ parseSymbol (Id ("u" <> Text.pack (show n)))
 
 -- | Parses a pointer to a type.
-parsePointerType :: Parser Type
+parsePointerType :: (?parserFlags :: ParserFlags) => Parser Type
 parsePointerType = parseSymbol Star *> (Ptr <$> located parseType)
 
 -- | Parses a pointer to a stack type.
-parseStackPointerType :: Parser Type
+parseStackPointerType :: (?parserFlags :: ParserFlags) => Parser Type
 parseStackPointerType = parseSymbol Sptr *> (SPtr <$> parseStackType)
 
 -- | Parses a stack type.
-parseStackType :: Parser (Located Type)
+parseStackType :: (?parserFlags :: ParserFlags) => Parser (Located Type)
 parseStackType = foldr1 cons <$> (located parseType `sepBy1` parseSymbol DoubleColon)
   where
     cons stack@(_ :@ p) ty = Cons stack ty :@ p
 
 -- | Parses a type variable.
-parseVariableType :: Parser Type
+parseVariableType :: (?parserFlags :: ParserFlags) => Parser Type
 parseVariableType = Var <$> parseIdentifier
 
 -- | Parses a type kind.
-parseKind :: Parser Kind
+parseKind :: (?parserFlags :: ParserFlags) => Parser Kind
 parseKind = MP.choice
   [ T8 <$ parseSymbol (Id "T8")
   , Ts <$ parseSymbol (Id "Ts")
@@ -234,38 +235,38 @@ parseKind = MP.choice
 ------------------------------------------------------------------------------------------------------------
 
 -- | Parses any kind of expression.
-parseExpr :: Parser Expr
+parseExpr :: (?parserFlags :: ParserFlags) => Parser Expr
 parseExpr = parseValueExpr MP.<|> parseAddressExpr
 
 -- | Parses only expressions that cannot be indexed.
-parseValueExpr :: Parser Expr
+parseValueExpr :: (?parserFlags :: ParserFlags) => Parser Expr
 parseValueExpr = lexeme $ MP.choice
   [ Imm <$> located parseImmediate ]
 
 -- | Parses an immediate literal value.
-parseImmediate :: Parser Immediate
+parseImmediate :: (?parserFlags :: ParserFlags) => Parser Immediate
 parseImmediate = MP.choice
   [ I . unLoc <$> parseInteger
   , C . unLoc <$> parseCharacter ]
 
 -- | Parses expressions that can be set and indexed.
-parseAddressExpr :: Parser Expr
+parseAddressExpr :: (?parserFlags :: ParserFlags) => Parser Expr
 parseAddressExpr = lexeme $ MP.choice
   [ parseLabel
   , Reg <$> located parseRegister
   , parseIndexedExpr ]
 
 -- | Parses a literal label name.
-parseLabel :: Parser Expr
+parseLabel :: (?parserFlags :: ParserFlags) => Parser Expr
 parseLabel = Name <$> parseIdentifier
 
 -- | Parses an indexed addressable expression.
-parseIndexedExpr :: Parser Expr
+parseIndexedExpr :: (?parserFlags :: ParserFlags) => Parser Expr
 parseIndexedExpr = MP.label "an indexed expression" $
   Indexed <$> located parseSignedInteger
           <*> betweenParens (located parseAddressExpr)
 
-parseSignedInteger :: Parser Integer
+parseSignedInteger :: (?parserFlags :: ParserFlags) => Parser Integer
 parseSignedInteger = (*) <$> sign <*> (unLoc <$> parseInteger)
  where
    sign = MP.choice [ -1 <$ parseSymbol Minus, 1 <$ pure () ]
@@ -273,12 +274,12 @@ parseSignedInteger = (*) <$> sign <*> (unLoc <$> parseInteger)
 ----------------------------------------------------------------------------------------------------------------
 
 -- | Parses a @mov@ instruction.
-parseMov :: Parser Instruction
+parseMov :: (?parserFlags :: ParserFlags) => Parser Instruction
 parseMov =
   parseSymbol Mov *>
     (MOV <$> located parseExpr
          <*> (parseSymbol Comma *> located parseAddressExpr))
 
 -- | Parses a @ret@ instruction.
-parseRet :: Parser Instruction
+parseRet :: (?parserFlags :: ParserFlags) => Parser Instruction
 parseRet = RET <$ parseSymbol Ret

--- a/lib/nsc-pretty/nsc-pretty.cabal
+++ b/lib/nsc-pretty/nsc-pretty.cabal
@@ -16,7 +16,7 @@ library
       Paths_nsc_pretty
   hs-source-dirs:
       src
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   ghc-options: -Wall -Wno-unused-matches -Wno-orphans
   build-depends:
       ansi-wl-pprint

--- a/lib/nsc-typechecker/nsc-typechecker.cabal
+++ b/lib/nsc-typechecker/nsc-typechecker.cabal
@@ -31,6 +31,7 @@ library
     , diagnose
     , mtl
     , nsc-core
+    , nsc-flags
     , nsc-pretty
     , text
   default-language: Haskell2010

--- a/lib/nsc-typechecker/nsc-typechecker.cabal
+++ b/lib/nsc-typechecker/nsc-typechecker.cabal
@@ -22,7 +22,7 @@ library
       Paths_nsc_typechecker
   hs-source-dirs:
       src
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   ghc-options: -Wall -Wno-name-shadowing -Wno-unused-matches -Wno-unused-do-bind
   build-depends:
       ansi-wl-pprint

--- a/lib/nsc-typechecker/package.yaml
+++ b/lib/nsc-typechecker/package.yaml
@@ -13,6 +13,7 @@ dependencies:
 - text
 - ansi-wl-pprint
 - nsc-pretty
+- nsc-flags
 
 default-extensions: !include "../../default-extensions.yaml"
 

--- a/nsc-lib.cabal
+++ b/nsc-lib.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1c190a028397dbb46848f78cd47ea1734f553890db5fb7bfe82e48d9bf18d781
+-- hash: d48fcfe42acb49d5f9554543a681fd11cd91028174ba620358151a3721adb310
 
 name:           nsc-lib
 version:        0.0.1.0
@@ -77,6 +77,7 @@ test-suite nsc-tests
     , diagnose
     , hspec
     , nsc-core
+    , nsc-flags
     , nsc-lib
     , nsc-parser
     , nsc-typechecker

--- a/nsc-lib.cabal
+++ b/nsc-lib.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: db8432dc46705ecd0c9a23ff3138b17f26272044df3a3423b0f50f4b60fc7e11
+-- hash: 1c190a028397dbb46848f78cd47ea1734f553890db5fb7bfe82e48d9bf18d781
 
 name:           nsc-lib
 version:        0.0.1.0
@@ -33,7 +33,7 @@ library
       Paths_nsc_lib
   hs-source-dirs:
       src
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   build-depends:
       base >=4.7 && <5
     , diagnose
@@ -48,7 +48,7 @@ executable nsc
       Paths_nsc_lib
   hs-source-dirs:
       app
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
@@ -69,7 +69,7 @@ test-suite nsc-tests
       Paths_nsc_lib
   hs-source-dirs:
       test
-  default-extensions: BlockArguments LambdaCase BinaryLiterals
+  default-extensions: BlockArguments LambdaCase BinaryLiterals ImplicitParams
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Glob

--- a/nsc-lib.cabal
+++ b/nsc-lib.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4c902c6c8f43fa9acc6448a9a1a3c3d8053710f7b582c2956981bf4b6de210b8
+-- hash: 41188c059496c99f0b27fcb88ff8b1bfa9e08e348f340aa8781a84f1b1461bf4
 
 name:           nsc-lib
 version:        0.0.1.0
@@ -54,6 +54,7 @@ executable nsc
       base >=4.7 && <5
     , diagnose
     , nsc-core
+    , nsc-flags
     , nsc-lib
     , nsc-parser
     , nsc-typechecker

--- a/nsc-lib.cabal
+++ b/nsc-lib.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 41188c059496c99f0b27fcb88ff8b1bfa9e08e348f340aa8781a84f1b1461bf4
+-- hash: db8432dc46705ecd0c9a23ff3138b17f26272044df3a3423b0f50f4b60fc7e11
 
 name:           nsc-lib
 version:        0.0.1.0
@@ -52,6 +52,7 @@ executable nsc
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , containers
     , diagnose
     , nsc-core
     , nsc-flags

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - nsc-lib
+    - nsc-flags
     - hspec
     - text
     - Glob

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - nsc-lib
+    - nsc-flags
     - text
 
 tests:

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ executables:
     - nsc-lib
     - nsc-flags
     - text
+    - containers
 
 tests:
   nsc-tests:

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
 - ./lib/nsc-parser
 - ./lib/nsc-typechecker
 - ./lib/nsc-pretty
+- ./lib/nsc-flags
 
 extra-deps:
 - git: https://github.com/mesabloo/diagnose.git

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ImplicitParams #-}
 
 module Main (main) where
 
@@ -12,6 +13,7 @@ import Language.NStar.Typechecker (typecheck)
 import Data.List (isInfixOf)
 import Text.Diagnose ((<~<), prettyText)
 import Data.Bifunctor (first)
+import Console.NStar.Flags (LexerFlags(..), ParserFlags(..), TypecheckerFlags(..))
 
 data Error
   = Lx
@@ -61,6 +63,10 @@ check file = do
            | otherwise                    -> No
 
   let result = do
+        let ?lexerFlags  = LexerFlags {}
+        let ?parserFlags = ParserFlags {}
+        let ?tcFlags     = TypecheckerFlags {}
+
         tokens <- first (, Lx) $ lexFile file content
         ast <- first (, Ps) $ parseFile file tokens
         ast <- first (, Tc) $ typecheck ast


### PR DESCRIPTION
Resolves #15 

This PR implements a simple template on which it should be fairly easy to add specific command-line flags like `-W<some warning name>`.
Only `-fcolor-diagnostics=yes|no` is implemented at the moment (with all the checks it needs), whose purpose is only to indicate whether we want colors in diagnostics or not.